### PR TITLE
removing `-e EMAIL` param from `docker login`

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -72,7 +72,7 @@ workflows:
             #!/bin/bash
             set -e
             echo "=> Docker login..."
-            docker login -e "${DOCKER_LOGIN_EMAIL}" -u "${DOCKER_LOGIN_USER}" -p "${DOCKER_LOGIN_PASS}"
+            docker login -u "${DOCKER_LOGIN_USER}" -p "${DOCKER_LOGIN_PASS}"
     - script@1.1.0:
         title: docker push
         inputs:


### PR DESCRIPTION
no longer supported in the latest docker version and it was deprecated for a long time now